### PR TITLE
Add bottle rating functionality

### DIFF
--- a/migrations/Version20250728150000.php
+++ b/migrations/Version20250728150000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250728150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add rating table and relation to bottles';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE rating (id INT AUTO_INCREMENT NOT NULL, bottle_id INT NOT NULL, user_id INT NOT NULL, value INT NOT NULL, INDEX IDX_D889262B83917B06 (bottle_id), INDEX IDX_D889262BA76ED395 (user_id), UNIQUE INDEX rating_unique_user_bottle (bottle_id, user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE rating ADD CONSTRAINT FK_D889262B83917B06 FOREIGN KEY (bottle_id) REFERENCES bottles (id)');
+        $this->addSql('ALTER TABLE rating ADD CONSTRAINT FK_D889262BA76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE rating');
+    }
+}
+

--- a/src/Entity/Rating.php
+++ b/src/Entity/Rating.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\RatingRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: RatingRepository::class)]
+#[ORM\UniqueConstraint(name: 'rating_unique_user_bottle', columns: ['bottle_id', 'user_id'])]
+class Rating
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'ratings')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Bottles $bottle = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    #[ORM\Column]
+    private ?int $value = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getBottle(): ?Bottles
+    {
+        return $this->bottle;
+    }
+
+    public function setBottle(?Bottles $bottle): static
+    {
+        $this->bottle = $bottle;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getValue(): ?int
+    {
+        return $this->value;
+    }
+
+    public function setValue(int $value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+}
+

--- a/src/Repository/RatingRepository.php
+++ b/src/Repository/RatingRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Rating;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Rating>
+ */
+class RatingRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Rating::class);
+    }
+}
+

--- a/templates/wine/wine.html.twig
+++ b/templates/wine/wine.html.twig
@@ -35,6 +35,19 @@
                 <p class="view-description" id="bouteille-description-full-{{ wine.id }}">
                     {{ wine.description }}
                 </p>
+                <p class="average-rating">
+                    Average rating: {{ wine.getAverageRating() is not null ? (wine.getAverageRating()|number_format(1)) : 'No rating yet' }}
+                </p>
+                {% if app.user %}
+                <form action="{{ path('rate', {id: wine.id}) }}" method="POST" class="rating-form">
+                    <select name="rating">
+                        {% for i in 1..5 %}
+                            <option value="{{ i }}" {% if wine.getUserRating(app.user) == i %}selected{% endif %}>{{ i }}</option>
+                        {% endfor %}
+                    </select>
+                    <button type="submit" class="btn">Rate</button>
+                </form>
+                {% endif %}
                 <div class="actions">
                 {# if (not in myCave) #}
                     <form action="{{ path('add', { id: wine.id }) }}" method="POST" style="display:inline">

--- a/tests/RatingTest.php
+++ b/tests/RatingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Bottles;
+use App\Entity\Rating;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class RatingTest extends TestCase
+{
+    public function testAverageRatingUpdatesWithUserChange(): void
+    {
+        $bottle = new Bottles();
+        $user = new User();
+        $user->setUsername('tester');
+        $user->setPassword('pass');
+
+        $rating = new Rating();
+        $rating->setBottle($bottle);
+        $rating->setUser($user);
+        $rating->setValue(4);
+        $bottle->addRating($rating);
+
+        $this->assertSame(4.0, $bottle->getAverageRating());
+        $this->assertSame(4, $bottle->getUserRating($user));
+
+        $rating->setValue(2);
+        $this->assertSame(2.0, $bottle->getAverageRating());
+        $this->assertSame(2, $bottle->getUserRating($user));
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow authenticated users to submit and update ratings for wines
- show average and personal ratings on wine listing
- create database table for ratings and related entity
- add unit test for rating behavior

## Testing
- `composer install --no-interaction --no-progress` (failed: Failed to clone https://github.com/symfony/flex.git)
- `./vendor/bin/phpunit tests/RatingTest.php` (failed: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_6895bfed93d0832a934acb2ce162a8ef